### PR TITLE
LE-118 Fix issue when user reload dashboard page 

### DIFF
--- a/assets/js/pages/index/dashboard.js
+++ b/assets/js/pages/index/dashboard.js
@@ -84,7 +84,7 @@ export class DashboardPage extends Component {
             this.setState({
                 tables,
                 filters,
-            }, () => this.setDataCookies(newFilters, this.state.dateRange))
+            }, () => this.setDataCookies(newFilters))
 
             await this.loadingData();
         }
@@ -319,7 +319,7 @@ export class DashboardPage extends Component {
                 })
             }
 
-            this.setDataCookies(filters, null);
+            this.setDataCookies(filters);
 
             return {
                 filters,
@@ -351,7 +351,7 @@ export class DashboardPage extends Component {
                 filters.map((item, index) => ({...item, id:index}));
             }
 
-            this.setDataCookies(filters, null);
+            this.setDataCookies(filters);
             return {
                 filters,
                 tables,


### PR DESCRIPTION
![Screen Shot 2021-04-13 at 13 51 15](https://user-images.githubusercontent.com/74392945/114509097-52ce2580-9c5f-11eb-9f1b-8372bf33641e.png)

When you user choose Custom Range and select date time range that user wanna filter. After that user will reload page and expect date time will be automatically set default in Date Range.

Issue: Cookies return Invalid date. 