### PR TITLE
Add platform to mysql-image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
             CLICKHOUSE_DB: "logs"
     mysql:
         image: percona:5.7
+        platform: linux/amd64
         environment:
             MYSQL_ROOT_PASSWORD: root
             MYSQL_DATABASE: dev


### PR DESCRIPTION
Fixing an issue on M1 mac with the error "no matching manifest for linux/arm64/v8 in the manifest list entries" with the result of a not starting logexplorer.