### PR TITLE
update clickhouse image for mac M1 compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
             - mysql
             - mailhog
     db:
-        image: yandex/clickhouse-server:21.2.7
+        image: yandex/clickhouse-server:22.1.3.7
         ports:
             - "127.0.0.1:9000:9000"
             - "127.0.0.1:8123:8123"


### PR DESCRIPTION
bump image yandex/clickhouse-server to 22.1.3.7 for mac M1 compatibility